### PR TITLE
Add Javier Zavaleta to ROLL-CALL.md file (#8)

### DIFF
--- a/ROLL-CALL.md
+++ b/ROLL-CALL.md
@@ -8,6 +8,7 @@ Add your [Dotfiles repo](https://github.com/eieioxyz/dotfiles_macos) to the list
 
 # Roll Call for [*Dotfiles from Start to Finish-ish*](http://dotfiles.eieio.xyz/)
 
+- [Javier Zavaleta](https://github.com/JavaZava/dotfiles): I'm a Technical Leader focused in web projects but who has worked in mobile as well. I love learning technologies and techniques that can be translated into making my team's life easier and removing roadblocks.
 - [Victor Mattos](https://github.com/vicmattos/dotfiles_macos): I'm a data engineer with a full-stack developer background and use python for everything. I love to create systems that make everyone's job easier and quicker.
 - [Simon Ward](https://github.com/simonward87/dotfiles): Full-stack web dev from London; Using React/Svelte, TypeScript, Node, and many of the surrounding technologies. Spent the last few months studying for the Kubernetes CKAD. I love design, outdoor cooking, swimming, and learning.
 - [Henrique Curzio Ladeira](https://github.com/henrique-c-ladeira/dotfiles-ubuntu): I'm a fullstack web and mobile dev. Mainly use typescript/javascript but I am fond of always learning new technologies and to improve my efficiency by working smarter not harder.


### PR DESCRIPTION
* chore: Add Javier Zavaleta to ROLL-CALL.md file

I have always worked with private repositories, so I've never had the chance to interact with forked projects.

* Move JavaZava to the top

Co-authored-by: Patrick McDonald <66495007+eieioxyz@users.noreply.github.com>